### PR TITLE
Basic Puppeteering Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "type": "module",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.10",
     "dotenv": "^16.0.0",
     "inquirer": "^8.1.5",
     "mongodb": "^4.5.0",
-    "node-fetch": "^3.0.0"
+    "node-fetch": "^3.0.0",
+    "puppeteer": "^14.0.0",
+    "striptags": "^3.2.0"
   }
 }

--- a/siteCrawler/index.js
+++ b/siteCrawler/index.js
@@ -1,0 +1,42 @@
+import puppeteer from 'puppeteer';
+import * as cheerio from 'cheerio';
+import striptags from 'striptags'
+
+async function crawl ({ url, root }) {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.setJavaScriptEnabled(false);
+  await page.goto(url, { waitUntil: 'networkidle0'});
+  await page.setViewport({ width: 1800, height: 900 });
+  const article = await page.$(root);
+  const html = await page.evaluate((article) => article.innerHTML, article);
+  await browser.close();
+  return { url, html }
+};
+
+const crawled = await crawl({ url: 'https://shinsina.github.io', root: 'body' });
+
+const { url, html } = crawled;
+
+const $ = cheerio.load(html, { }, false);
+
+const uniqueURL = new Set();
+
+$('*').each(function fn() {
+  if ('script' !== this.name) {
+    if (['img', 'a', 'iframe'].includes(this.name)) {
+      uniqueURL.add(this.attribs['data-src'] || this.attribs.href || this.attribs.src);
+      if (this.attribs['data-src'] || this.attribs.src) {
+        $(this).replaceWith($(`<a href="${this.attribs['data-src']||this.attribs.src}" target="_blank">Link</a> `))
+      }
+    }
+  }
+});
+
+const articleData = {
+  body: striptags(String($.html()), ['a', 'table', 'tr', 'td', 'th']).replace(/\n/g, '<br/>').replace(/  /g, '').replace(/(<br\/>)+/g, '<br/>'),
+  URLS: Array.from(uniqueURL),
+  url
+}
+
+console.log(articleData);


### PR DESCRIPTION
The example as it stands currently crawls my portfolio pages body copy and outputs unique URLs (via href/src attributes) found on the page as well as stripping all non-table or non-anchor tag tags to make somewhat of a "plain text version" with only table tags and break tags.