### PR TITLE
Improvements to image downloader utility

### DIFF
--- a/imageDownloader/.gitignore
+++ b/imageDownloader/.gitignore
@@ -1,0 +1,3 @@
+*.txt
+*.json
+Downloaded

--- a/imageDownloader/index.js
+++ b/imageDownloader/index.js
@@ -6,16 +6,27 @@ import inquirer from 'inquirer';
 const { log } = console;
 
 async function download(relativeFolder, item) {
-  const extractFileName = item.id ? item.url.match(/\/.+\/(.+)/) : item.match(/\/.+\/(.+)/);
-  const extractedFile = extractFileName[1];
+  const extractFileName = item.id ? item.url.match(/\/.+?\/(.+)/) : item.match(/\/.+?\/(.+)/);
+  const extractedPath = extractFileName[1];
+  const pathExploded = extractedPath.split('/');
+  const extractedFolderPath = pathExploded.slice(0, -1).join('/');
+  const extractedFile = pathExploded.pop();
   try {
     const filePath = item.id
-      ? `${relativeFolder}/${item.id}_${extractedFile}`
-      : `${relativeFolder}/${extractedFile}`;
+      ? `${relativeFolder}/${extractedFolderPath}/${item.id}_${extractedFile}`
+      : `${relativeFolder}/${extractedFolderPath}/${extractedFile}`;
+    const buildingPath = [];
+    pathExploded.forEach((folder) => {
+      buildingPath.push(folder);
+      const absolutePath = `${relativeFolder}/${buildingPath.join('/')}`;
+      if (!fs.existsSync(absolutePath)) {
+        fs.mkdirSync(absolutePath);
+      }
+    });
     if (!fs.existsSync(filePath)) {
       const response = item.id ? await fetch(item.url) : await fetch(item);
       const buffer = await response.buffer();
-      fs.writeFile(filePath, buffer, () => log(`Downloaded ${extractedFile}`));
+      fs.writeFile(filePath, buffer, () => log(`Downloaded to ${filePath}`));
     }
   } catch (e) {
     log(e);


### PR DESCRIPTION
In this PR:

Update (Add) gitignore. https://github.com/Shinsina/Shinsina-Utilities/commit/7ba952cf9b44c886c470ef0e11d3e0a75449e4f1

Improve the download helper function. https://github.com/Shinsina/Shinsina-Utilities/commit/4631907d382d999b1bc4c7243122b0c419fc4cd5

This makes it easier for when querying against a CDN (or likely a site using a CDN to hosts it's respective assets), to organize them in the structure they would have been in the underlying asset database (AWS S3, etc.).