### PR TITLE
Properly handle fully errored responses, checkIfPageExists

### DIFF
--- a/checkIfPageExists/index.js
+++ b/checkIfPageExists/index.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import fetch from 'node-fetch';
 import inquirer from 'inquirer';
 
+const { log } = console;
+
 const main = async () => {
   const { urlListFileName } = await inquirer.prompt([
     {
@@ -14,7 +16,17 @@ const main = async () => {
   const urls = [];
   const fileData = fs.readFileSync(urlListFileName);
   urls.push(...JSON.parse(fileData));
-  const fetched = await Promise.all(urls.map((url) => fetch(url)));
+  const fetched = await Promise.all(urls.map(async (url, index) => {
+    let response = '';
+    try {
+      const fetchOp = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      log(`Attempting to fetch ${index} of ${urls.length}...`);
+      response = { url, status: fetchOp.status };
+    } catch (error) {
+      response = { url, status: 404 };
+    }
+    return response;
+  }));
   const notFounds = fetched.filter((v) => v.status === 404).map((v) => v.url);
   fs.writeFileSync('./notFound.json', JSON.stringify(notFounds));
 };


### PR DESCRIPTION
Previously it was assumed that these would at least resolve at the DNS level but there are some cases that this doesn't work so we'll properly handle cases such as these within our `Promise.all` to attempt to catch as many of these as possible.